### PR TITLE
Fix shipping address save in KSS callback

### DIFF
--- a/src/module-vsf-kco/Controller/Order/AddressUpdate.php
+++ b/src/module-vsf-kco/Controller/Order/AddressUpdate.php
@@ -162,14 +162,18 @@ class AddressUpdate extends Action implements CsrfAwareActionInterface
         }
 
         if (isset($shippingMethodCode)) {
-            $this->logger->info('Shipping method code:' . $this->convertShippingMethodCode($shippingMethodCode));
+            $shippingMethodCode = $this->convertShippingMethodCode($shippingMethodCode);
+            $this->logger->info('Shipping method code:' . $shippingMethodCode);
             $quote->getShippingAddress()
-                ->setShippingMethod($this->convertShippingMethodCode($shippingMethodCode))
+                ->setShippingMethod($shippingMethodCode)
                 ->setCollectShippingRates(true)
                 ->collectShippingRates();
         }
 
-        $this->cartRepository->save($quote);
+        $quote->setTotalsCollectedFlag(false)
+            ->collectTotals()
+            ->save();
+
         $data->setOrderAmount(intval(round($quote->getShippingAddress()->getGrandTotal() * 100)));
         $data->setOrderTaxAmount(intval(round($quote->getShippingAddress()->getTaxAmount() * 100)));
 

--- a/src/module-vsf-kco/Controller/Order/ShippingOptionUpdate.php
+++ b/src/module-vsf-kco/Controller/Order/ShippingOptionUpdate.php
@@ -173,13 +173,16 @@ class ShippingOptionUpdate extends Action implements CsrfAwareActionInterface
             }
             $this->logger->info('ShippingMethodCode in SOU: '.$shippingMethodCode);
             if (isset($shippingMethodCode)) {
-                $quote->setTotalsCollectedFlag(false);
-                $quote->getShippingAddress()->setCollectShippingRates(true)->collectShippingRates();;
-                $quote->getShippingAddress()->setShippingMethod($shippingMethodCode);
-                $quote->getShippingAddress()->setShippingDescription($shippingDescription);
-                $quote->collectTotals();
+                $quote->getShippingAddress()
+                ->setShippingMethod($shippingMethodCode)
+                ->setShippingDescription($shippingDescription)
+                ->setCollectShippingRates(true)
+                ->collectShippingRates();
             }
-            $this->mageQuoteRepository->save($quote);
+
+            $quote->setTotalsCollectedFlag(false)
+                ->collectTotals()
+                ->save();
 
         } catch (\Exception $e) {
             $this->logger->info($e->getMessage());


### PR DESCRIPTION
The `quoteRepository->save($quote)` will not save the `shippingAddress` data. So we use `$quote->save()`