### PR TITLE
check if masked quote id is actually just quote id after unmask failure

### DIFF
--- a/src/module-vsf-kco/Controller/Order/AddressUpdate.php
+++ b/src/module-vsf-kco/Controller/Order/AddressUpdate.php
@@ -257,7 +257,11 @@ class AddressUpdate extends Action implements CsrfAwareActionInterface
 
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($mask, 'masked_id');
-        return $quoteIdMask->getQuoteId();
+        $quoteId = $quoteIdMask->getQuoteId();
+        if( (int)$quoteId==0 && ctype_digit(strval($mask))){
+            $quoteId = (int)$mask;
+        }
+        return $quoteId;
     }
 
     /**

--- a/src/module-vsf-kco/Controller/Order/Confirmation.php
+++ b/src/module-vsf-kco/Controller/Order/Confirmation.php
@@ -138,6 +138,9 @@ class Confirmation extends Action implements CsrfAwareActionInterface
         $maskedId = $placedKlarnaOrder->getDataByKey('merchant_reference2');
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($maskedId, 'masked_id');
         $quoteId = $quoteIdMask->getQuoteId();
+        if( (int)$quoteId==0 && ctype_digit(strval($maskedId))){
+            $quoteId = (int)$maskedId;
+        }
         $quote = $this->cartRepository->get($quoteId);
 
         $store = $quote->getStoreId();

--- a/src/module-vsf-kco/Controller/Order/Push.php
+++ b/src/module-vsf-kco/Controller/Order/Push.php
@@ -130,6 +130,9 @@ class Push extends Action implements CsrfAwareActionInterface
         $maskedId = $placedKlarnaOrder->getDataByKey('merchant_reference2');
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($maskedId, 'masked_id');
         $quoteId = $quoteIdMask->getQuoteId();
+        if( (int)$quoteId==0 && ctype_digit(strval($maskedId))){
+            $quoteId = (int)$maskedId;
+        }
         $quote = $this->cartRepository->get($quoteId);
         if (!$quote->getId()) {
             echo 'Quote is not existed in Magento';

--- a/src/module-vsf-kco/Controller/Order/ShippingOptionUpdate.php
+++ b/src/module-vsf-kco/Controller/Order/ShippingOptionUpdate.php
@@ -256,7 +256,11 @@ class ShippingOptionUpdate extends Action implements CsrfAwareActionInterface
 
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($mask, 'masked_id');
-        return $quoteIdMask->getQuoteId();
+        $quoteId = $quoteIdMask->getQuoteId();
+        if( (int)$quoteId==0 && ctype_digit(strval($mask))){
+            $quoteId = (int)$mask;
+        }
+        return $quoteId;
     }
 
     /**

--- a/src/module-vsf-kco/Controller/Order/Validate.php
+++ b/src/module-vsf-kco/Controller/Order/Validate.php
@@ -243,7 +243,11 @@ class Validate extends Action implements CsrfAwareActionInterface
 
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($mask, 'masked_id');
-        return $quoteIdMask->getQuoteId();
+        $quoteId = $quoteIdMask->getQuoteId();
+        if( (int)$quoteId==0 && ctype_digit(strval($mask))){
+            $quoteId = (int)$mask;
+        }
+        return $quoteId;
     }
 
     /**


### PR DESCRIPTION
- if a registered user makes a purchase `merchant_reference2` parameter contains quote id that is not masked
- unmasking this parameter fails 
- added check if quote id unmasking failed and if  merchant_reference2 is integer -> use it as quote id