### PR TITLE
BUGFIX: cart doesn't clear in Confirmation.

### DIFF
--- a/src/module-vsf-kco/Plugin/BeforeVsfPullCart.php
+++ b/src/module-vsf-kco/Plugin/BeforeVsfPullCart.php
@@ -33,10 +33,11 @@ class BeforeVsfPullCart
         $this->quoteRepository         = $quoteRepository;
     }
 
+
     /**
      * @param \Magento\Quote\Model\Quote\Item\Repository $subject
      * @param $cartId
-     * @return int
+     * @return array
      * @throws \Magento\Framework\Exception\CouldNotSaveException
      */
     public function beforeGetList(
@@ -48,6 +49,7 @@ class BeforeVsfPullCart
         }catch (NoSuchEntityException $e) {
             $cartId = $this->cartManagement->createEmptyCart();
         }
-        return $cartId;
+
+        return [$cartId];
     }
 }

--- a/src/module-vsf-kco/Plugin/BeforeVsfPullCart.php
+++ b/src/module-vsf-kco/Plugin/BeforeVsfPullCart.php
@@ -37,7 +37,6 @@ class BeforeVsfPullCart
      * @param \Magento\Quote\Model\Quote\Item\Repository $subject
      * @param $cartId
      * @return int
-     * @throws NoSuchEntityException
      * @throws \Magento\Framework\Exception\CouldNotSaveException
      */
     public function beforeGetList(
@@ -47,13 +46,7 @@ class BeforeVsfPullCart
         try {
             $this->quoteRepository->getActive($cartId);
         }catch (NoSuchEntityException $e) {
-            $quote = $this->quoteRepository->get($cartId);
-
-            if ( $quote->getCustomer() && $quote->getCustomer()->getId() ) {
-                $cartId = $this->cartManagement->createEmptyCartForCustomer($quote->getCustomer()->getId());
-            } else {
-                $cartId = $this->cartManagement->createEmptyCart();
-            }
+            $cartId = $this->cartManagement->createEmptyCart();
         }
         return $cartId;
     }

--- a/src/module-vsf-kco/Plugin/BeforeVsfPullCart.php
+++ b/src/module-vsf-kco/Plugin/BeforeVsfPullCart.php
@@ -37,6 +37,7 @@ class BeforeVsfPullCart
      * @param \Magento\Quote\Model\Quote\Item\Repository $subject
      * @param $cartId
      * @return int
+     * @throws NoSuchEntityException
      * @throws \Magento\Framework\Exception\CouldNotSaveException
      */
     public function beforeGetList(
@@ -46,7 +47,13 @@ class BeforeVsfPullCart
         try {
             $this->quoteRepository->getActive($cartId);
         }catch (NoSuchEntityException $e) {
-            $cartId = $this->cartManagement->createEmptyCart();
+            $quote = $this->quoteRepository->get($cartId);
+
+            if ( $quote->getCustomer() && $quote->getCustomer()->getId() ) {
+                $cartId = $this->cartManagement->createEmptyCartForCustomer($quote->getCustomer()->getId());
+            } else {
+                $cartId = $this->cartManagement->createEmptyCart();
+            }
         }
         return $cartId;
     }

--- a/src/module-vsf-kco/Plugin/BeforeVsfPullCart.php
+++ b/src/module-vsf-kco/Plugin/BeforeVsfPullCart.php
@@ -1,0 +1,53 @@
+<?php
+namespace Kodbruket\VsfKco\Plugin;
+
+use Magento\Framework\Exception\NoSuchEntityException;
+
+/**
+ * Class BeforeVsfPullCart
+ * @package Kodbruket\VsfKco\Plugin
+ */
+class BeforeVsfPullCart
+{
+    /**
+     * @var \Magento\Quote\Api\CartManagementInterface
+     */
+    private $cartManagement;
+
+    /**
+     * @var \Magento\Quote\Api\CartRepositoryInterface
+     */
+    private $quoteRepository;
+
+    /**
+     * BeforeVsfPullCart constructor.
+     * @param \Magento\Quote\Api\CartManagementInterface $cartManagement
+     * @param \Magento\Quote\Api\CartRepositoryInterface $quoteRepository
+     */
+    public function __construct(
+        \Magento\Quote\Api\CartManagementInterface $cartManagement,
+        \Magento\Quote\Api\CartRepositoryInterface $quoteRepository
+    )
+    {
+        $this->cartManagement          = $cartManagement;
+        $this->quoteRepository         = $quoteRepository;
+    }
+
+    /**
+     * @param \Magento\Quote\Model\Quote\Item\Repository $subject
+     * @param $cartId
+     * @return int
+     * @throws \Magento\Framework\Exception\CouldNotSaveException
+     */
+    public function beforeGetList(
+        \Magento\Quote\Model\Quote\Item\Repository $subject,
+        $cartId
+    ) {
+        try {
+            $this->quoteRepository->getActive($cartId);
+        }catch (NoSuchEntityException $e) {
+            $cartId = $this->cartManagement->createEmptyCart();
+        }
+        return $cartId;
+    }
+}

--- a/src/module-vsf-kco/etc/webapi_rest/di.xml
+++ b/src/module-vsf-kco/etc/webapi_rest/di.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Quote\Model\Quote\Item\Repository">
+        <plugin name="before_vsf_pull_cart" type="Kodbruket\VsfKco\Plugin\BeforeVsfPullCart" />
+    </type>
+</config>


### PR DESCRIPTION
Slack link: https://kodbruket.slack.com/archives/GNG4EM9QQ/p1575527251002200?thread_ts=1575515309.000500&cid=GNG4EM9QQ

Scenario:
1. Customer places an order -> quote is disabled in Confirmation
2. VSF shows Confirmation page then VSF calls `pull-cart` request -> it will throw the error because this line: https://github.com/magento/magento2/blob/2.3/app/code/Magento/Quote/Model/Quote/Item/Repository.php#L70 -> then VSF will not able to clear the cart client items.

So we need to add a plugin to handle this issue since we changed the concept of callback - We only create an order in PushController.
