### PR TITLE
fix: set contents for 200 response

### DIFF
--- a/src/module-vsf-kco/Controller/Order/Validate.php
+++ b/src/module-vsf-kco/Controller/Order/Validate.php
@@ -185,7 +185,7 @@ class Validate extends Action implements CsrfAwareActionInterface
                 ->collectTotals()
                 ->save();
 
-            return $this->resultFactory->create(ResultFactory::TYPE_RAW)->setHttpResponseCode(200);
+            return $this->resultFactory->create(ResultFactory::TYPE_RAW)->setContents("")->setHttpResponseCode(200);
         } catch (\Exception $exception) {
             $this->logger->critical('validation save kco Order' . $exception->getMessage());
             return $this->setValidateFailedResponse();


### PR DESCRIPTION
Not setting the content results in a 500 instead of the intended 200.